### PR TITLE
inherit prompt colour

### DIFF
--- a/main.go
+++ b/main.go
@@ -94,7 +94,6 @@ func main() {
 		p := prompt.New(exec.execute, c.suggest,
 			prompt.OptionWriter(&CustomWriter{}),
 			prompt.OptionPrefix(dbName+"> "),
-			prompt.OptionPrefixTextColor(prompt.DarkGray),
 			prompt.OptionHistory(h.load()),
 		)
 


### PR DESCRIPTION
Inherit the prompt colour from the session as it was invisible on some backgrounds. Tested on solarized light and dark, and both look fine.